### PR TITLE
Make it pass desktop-file-validate

### DIFF
--- a/AppImage/default.desktop
+++ b/AppImage/default.desktop
@@ -5,3 +5,4 @@ Exec=AppRun %F
 Icon=default
 Comment=AnimationMaker
 Terminal=true
+Categories=Graphics;


### PR DESCRIPTION
Please close this only after a new release containing this fix is available. Then I can add it to the AppImageHub central directory of available AppImages.