### PR TITLE
Fix memory leaks scenario 3

### DIFF
--- a/src/App/widgets/animationitem.cpp
+++ b/src/App/widgets/animationitem.cpp
@@ -80,12 +80,13 @@ AnimationItem::~AnimationItem()
     for(it = m_keyframes->begin(); it != m_keyframes->end(); it++)
     {
         KeyFrame *frame = it.value();
-        for(; frame != nullptr; frame = frame->next())
-        {
-            if(frame->prev())
-                delete frame->prev();
+        KeyFrame *next = nullptr;
+        while (frame) {
+            next = frame->next();
+            delete frame;
+
+            frame = next;
         }
-        delete frame;
     }
     delete m_contextMenu;
     delete m_keyframes;

--- a/src/App/widgets/keyframehandle.cpp
+++ b/src/App/widgets/keyframehandle.cpp
@@ -49,6 +49,13 @@ KeyframeHandle::KeyframeHandle(TransitionLine *parent, KeyFrame *key)
     setContextMenuPolicy(Qt::CustomContextMenu);
 }
 
+KeyframeHandle::~KeyframeHandle()
+{
+    delete m_delKeyframeAct;
+    delete m_transitionAct;
+    delete m_contextMenu;
+}
+
 void KeyframeHandle::paintEvent(QPaintEvent *)
 {
     QPainter painter(this);

--- a/src/App/widgets/keyframehandle.h
+++ b/src/App/widgets/keyframehandle.h
@@ -38,6 +38,7 @@ class KeyframeHandle : public QWidget
     Q_OBJECT
 public:
     KeyframeHandle(TransitionLine *parent, KeyFrame *key);
+    ~KeyframeHandle();
 
     void paintEvent(QPaintEvent *ev) Q_DECL_OVERRIDE;
     void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;

--- a/src/App/widgets/timeline.cpp
+++ b/src/App/widgets/timeline.cpp
@@ -357,10 +357,10 @@ void Timeline::treeCurrentItemChanged(QTreeWidgetItem *currentItem, QTreeWidgetI
 {
     if(currentItem)
     {
-        QVariant level = currentItem->data(1,0);
+        QVariant level = currentItem->data(1, Qt::DisplayRole);
         if(level == 1)
         {
-            AnimationItem *item = (AnimationItem *)currentItem->data(0,1).value<void *>();
+            AnimationItem *item = (AnimationItem *)currentItem->data(0, Qt::DecorationRole).value<void *>();
             if(item)
                 emit itemSelectionChanged(item);
         }
@@ -372,7 +372,7 @@ QTreeWidgetItem *Timeline::search(AnimationItem *item)
     for(int i=0; i < m_tree->topLevelItemCount(); i++)
     {
         QTreeWidgetItem *twi = m_tree->topLevelItem(i);
-        if(twi->data(0, 1).value<void *>() == item)
+        if(twi->data(0, Qt::DecorationRole).value<void *>() == item)
             return twi;
     }
     return nullptr;
@@ -549,8 +549,8 @@ void Timeline::addKeyFrame(AnimationItem *item, QString propertyName, KeyFrame *
     {
         treeItem = new QTreeWidgetItem();
         treeItem->setText(0, item->id());
-        treeItem->setData(0, 1, qVariantFromValue((void *) item));
-        treeItem->setData(1, 0, 1);
+        treeItem->setData(0, Qt::DecorationRole, QVariant::fromValue((void *) item));
+        treeItem->setData(1, Qt::DisplayRole, 1);
         connect(item, SIGNAL(idChanged(AnimationItem *, QString)), this, SLOT(idChanged(AnimationItem *, QString)));
         m_tree->addTopLevelItem(treeItem);
         addTransitionLine(treeItem, item);
@@ -559,9 +559,9 @@ void Timeline::addKeyFrame(AnimationItem *item, QString propertyName, KeyFrame *
     item->addKeyframe(propertyName, key);
     if(treeChildItem)
     {
-        QVariantList list = treeChildItem->data(0, 1).toList();
+        QVariantList list = treeChildItem->data(0, Qt::DecorationRole).toList();
         list.append(QVariant::fromValue(key));
-        treeChildItem->setData(0, 1, list);
+        treeChildItem->setData(0, Qt::DecorationRole, list);
         addPropertyKey(treeChildItem, item, propertyName, key);
     }
     else
@@ -570,8 +570,8 @@ void Timeline::addKeyFrame(AnimationItem *item, QString propertyName, KeyFrame *
         list.append(key);
         treeChildItem = new QTreeWidgetItem();
         treeChildItem->setText(0, propertyName);
-        treeChildItem->setData(0, 1, qVariantFromValue(list));
-        treeChildItem->setData(1, 0, 2);
+        treeChildItem->setData(0, Qt::DecorationRole, QVariant::fromValue(list));
+        treeChildItem->setData(1, Qt::DisplayRole, 2);
         treeItem->addChild(treeChildItem);
 
         addProperty(treeChildItem, item, propertyName);
@@ -593,8 +593,8 @@ void Timeline::keyframeAdded(AnimationItem * item, QString propertyName, KeyFram
     {
         treeItem = new QTreeWidgetItem();
         treeItem->setText(0, item->id());
-        treeItem->setData(0, 1, qVariantFromValue((void *) item));
-        treeItem->setData(1, 0, 1);
+        treeItem->setData(0, Qt::DecorationRole, QVariant::fromValue((void *) item));
+        treeItem->setData(1, Qt::DisplayRole, 1);
         connect(item, SIGNAL(idChanged(AnimationItem *, QString)), this, SLOT(idChanged(AnimationItem *, QString)));
         m_tree->addTopLevelItem(treeItem);
         addTransitionLine(treeItem, item);
@@ -602,9 +602,9 @@ void Timeline::keyframeAdded(AnimationItem * item, QString propertyName, KeyFram
 
     if(treeChildItem)
     {
-        QVariantList list = treeChildItem->data(0, 1).toList();
+        QVariantList list = treeChildItem->data(0, Qt::DecorationRole).toList();
         list.append(QVariant::fromValue(key));
-        treeChildItem->setData(0, 1, list);
+        treeChildItem->setData(0, Qt::DecorationRole, list);
         addPropertyKey(treeChildItem, item, propertyName, key);
     }
     else
@@ -613,8 +613,8 @@ void Timeline::keyframeAdded(AnimationItem * item, QString propertyName, KeyFram
         list.append(key);
         treeChildItem = new QTreeWidgetItem();
         treeChildItem->setText(0, propertyName);
-        treeChildItem->setData(0, 1, qVariantFromValue(list));
-        treeChildItem->setData(1, 0, 2);
+        treeChildItem->setData(0, Qt::DecorationRole, QVariant::fromValue(list));
+        treeChildItem->setData(1, Qt::DisplayRole, 2);
         treeItem->addChild(treeChildItem);
         addProperty(treeChildItem, item, propertyName);
         addPropertyKey(treeChildItem, item, propertyName, key);
@@ -638,7 +638,7 @@ void Timeline::removeItem(AnimationItem *item)
     for(int i=0; i < m_tree->topLevelItemCount(); i++)
     {
         QTreeWidgetItem *treeItem = m_tree->topLevelItem(i);
-        if(treeItem->data(0, 1).value<void *>() == item)
+        if(treeItem->data(0, Qt::DecorationRole).value<void *>() == item)
         {
             m_tree->takeTopLevelItem(i);
             delete treeItem;
@@ -651,7 +651,7 @@ void Timeline::selectItem(AnimationItem *item)
     for(int i=0; i < m_tree->topLevelItemCount(); i++)
     {
         QTreeWidgetItem *treeItem = m_tree->topLevelItem(i);
-        if(treeItem->data(0, 1).value<void *>() == item)
+        if(treeItem->data(0, Qt::DecorationRole).value<void *>() == item)
             treeItem->setSelected(true);
         else
             treeItem->setSelected(false);
@@ -664,7 +664,7 @@ int Timeline::lastKeyframe()
     for(int i = 0; i < m_tree->topLevelItemCount(); i++)
     {
         QTreeWidgetItem *treeItem = m_tree->topLevelItem(i);
-        AnimationItem *item = (AnimationItem *) treeItem->data(0, 1).value<void *>();
+        AnimationItem *item = (AnimationItem *) treeItem->data(0, Qt::DecorationRole).value<void *>();
 
         QHash<QString, KeyFrame*>::iterator it;
         for (it = item->keyframes()->begin(); it != item->keyframes()->end(); it++)

--- a/src/App/widgets/timeline.cpp
+++ b/src/App/widgets/timeline.cpp
@@ -136,6 +136,7 @@ Timeline::~Timeline()
     delete m_pauseAct;
     delete m_playAct;
     delete m_reverseAct;
+    delete m_tree;
 }
 
 void Timeline::scrollValueChanged(int value)
@@ -558,20 +559,21 @@ void Timeline::addKeyFrame(AnimationItem *item, QString propertyName, KeyFrame *
     item->addKeyframe(propertyName, key);
     if(treeChildItem)
     {
-        QVariant var = treeChildItem->data(0, 1);
-        QList<KeyFrame*> *list = (QList<KeyFrame*>*) var.value<void *>();
-        list->append(key);
+        QVariantList list = treeChildItem->data(0, 1).toList();
+        list.append(QVariant::fromValue(key));
+        treeChildItem->setData(0, 1, list);
         addPropertyKey(treeChildItem, item, propertyName, key);
     }
     else
     {
-        QList<KeyFrame*> *list = new QList<KeyFrame*>();
-        list->append(key);
+        QList<KeyFrame*> list = QList<KeyFrame *>();
+        list.append(key);
         treeChildItem = new QTreeWidgetItem();
         treeChildItem->setText(0, propertyName);
-        treeChildItem->setData(0, 1, qVariantFromValue((void *) list));
+        treeChildItem->setData(0, 1, qVariantFromValue(list));
         treeChildItem->setData(1, 0, 2);
         treeItem->addChild(treeChildItem);
+
         addProperty(treeChildItem, item, propertyName);
         addPropertyKey(treeChildItem, item, propertyName, key);
     }
@@ -600,18 +602,18 @@ void Timeline::keyframeAdded(AnimationItem * item, QString propertyName, KeyFram
 
     if(treeChildItem)
     {
-        QVariant var = treeChildItem->data(0, 1);
-        QList<KeyFrame*> *list = (QList<KeyFrame*>*) var.value<void *>();
-        list->append(key);
+        QVariantList list = treeChildItem->data(0, 1).toList();
+        list.append(QVariant::fromValue(key));
+        treeChildItem->setData(0, 1, list);
         addPropertyKey(treeChildItem, item, propertyName, key);
     }
     else
     {
-        QList<KeyFrame*> *list = new QList<KeyFrame*>();
-        list->append(key);
+        QList<KeyFrame*> list = QList<KeyFrame*>();
+        list.append(key);
         treeChildItem = new QTreeWidgetItem();
         treeChildItem->setText(0, propertyName);
-        treeChildItem->setData(0, 1, qVariantFromValue((void *) list));
+        treeChildItem->setData(0, 1, qVariantFromValue(list));
         treeChildItem->setData(1, 0, 2);
         treeItem->addChild(treeChildItem);
         addProperty(treeChildItem, item, propertyName);

--- a/src/App/widgets/transition.cpp
+++ b/src/App/widgets/transition.cpp
@@ -58,6 +58,12 @@ Transition::Transition(TransitionLine *parent, KeyFrame *key, Timeline *timeline
     setVisible(true);
 }
 
+Transition::~Transition()
+{
+    delete m_contextMenu;
+    delete m_transitionAct;
+}
+
 void Transition::paintEvent(QPaintEvent *)
 {
     QColor orange(255, 127, 42, 150);

--- a/src/App/widgets/transition.h
+++ b/src/App/widgets/transition.h
@@ -39,6 +39,7 @@ class Transition : public QWidget
     Q_OBJECT
 public:
     Transition(TransitionLine *parent, KeyFrame *key, Timeline *timeline, QUndoStack *undostack);
+    ~Transition();
 
     void paintEvent(QPaintEvent *ev) Q_DECL_OVERRIDE;
     void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;

--- a/src/App/widgets/transitionhandleleft.cpp
+++ b/src/App/widgets/transitionhandleleft.cpp
@@ -37,6 +37,12 @@ TransitionHandleLeft::TransitionHandleLeft(Transition *parent, KeyFrame *key)
     setContextMenuPolicy(Qt::CustomContextMenu);
 }
 
+TransitionHandleLeft::~TransitionHandleLeft()
+{
+    delete m_transitionAct;
+    delete m_contextMenu;
+}
+
 void TransitionHandleLeft::onCustomContextMenu(const QPoint &point)
 {
     m_contextMenu->clear();

--- a/src/App/widgets/transitionhandleleft.h
+++ b/src/App/widgets/transitionhandleleft.h
@@ -33,6 +33,7 @@ class TransitionHandleLeft : public TransitionHandle
     Q_OBJECT
 public:
     TransitionHandleLeft(Transition *parent, KeyFrame *key);
+    ~TransitionHandleLeft();
 
 protected:
     void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;


### PR DESCRIPTION
Fix memory leaks after running scenario 3.

Added necessary destructors, delete all keyframes in timeline destructor, use QVariantList for keyframe list, do not manually allocate the list anymore, create a local list and copy it into QVariantList, a little bit more code but less memory management.

replace all occurrences of constant numbers for `Qt::ItemDataRole` with pre-defines constants.