### PR TITLE
Closes #35 - Remove binaries from repository, better handle errors from ffmpeg

### DIFF
--- a/AppRun
+++ b/AppRun
@@ -1,4 +1,0 @@
-#!/bin/bash
-HERE="$(dirname "$(readlink -f "${0}")")"
-export LD_LIBRARY_PATH=${HERE}/lib:$LD_LIBRARY_PATH
-exec "${HERE}/bin/AnimationMaker" "$@"

--- a/binaries/xdg-open
+++ b/binaries/xdg-open
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-dbus-send --print-reply \
-          --session --dest=com.canonical.SafeLauncher \
-          / com.canonical.SafeLauncher.OpenURL \
-          string:"$1" 1> /dev/null 2> $SNAP_USER_DATA/xdg-open.err

--- a/src/App/widgets/mainwindow.h
+++ b/src/App/widgets/mainwindow.h
@@ -68,7 +68,7 @@ protected:
     void readSettings();
     void writeFile(QString fileName);
     void fillTree();
-    void runCommand(QString cmd, QString path);
+    void runExport(QStringList &args, QString path);
     void addCheckboxes(QTreeWidgetItem *treeItem, AnimationItem *item);
 
     QProcess *m_proc;
@@ -119,6 +119,7 @@ protected:
     QMenu *importMenu;
     QMenu *exportMenu;
     QUndoStack *m_undoStack;
+    const QString FFMPEG = "ffmpeg";
     
 public slots:
     void reset();


### PR DESCRIPTION
Check first that ffmpeg is installed on the system by running 'ffmpeg -version'.
Then run ffmpeg with the apropriate command.
If it encountered an error display a noticing message and ffmpeg message from standard error stream.

Closes #35 