### PR TITLE
Closes #42 - store version number in single header file.

### DIFF
--- a/build_package.sh
+++ b/build_package.sh
@@ -38,6 +38,17 @@ then
     echo "Plugin folder not found, build package without plugins"
 fi
 
+_extract_version()
+{
+    local seg="$1"
+    echo "$(grep "VERSION_${seg}" ./src/App/version.h | cut -d" "  -f 3)"
+}
+
+major=$(_extract_version "MAJOR")
+minor=$(_extract_version "MINOR")
+build=$(_extract_version "BUILD")
+VERSION="${major}.${minor}.${build}"
+
 # rename the binary to lowercase letter to comply with deb packages
 mv ${SOURCE_DIR}/AnimationMaker ${SOURCE_DIR}/animationmaker
 
@@ -67,6 +78,6 @@ fpm \
     -m "Alexandre LAVIGNE" \
     --description "${PACKAGE_DESCRIPTION}" \
     --url "https://github.com/Artanidos/AnimationMaker" \
-    --version 1.9 \
+    --version ${VERSION} \
     ${deps[@]} \
     animationmaker plugins

--- a/src/App/App.pro
+++ b/src/App/App.pro
@@ -42,8 +42,11 @@ LIBS += -L$$OUT_PWD/../AnimationItems -lAnimationItems
 SOURCES += main.cpp \
     mainwindow.cpp \
 
-
 HEADERS += \
     mainwindow.h \
+    version.h \
 
 RESOURCES += ../images.qrc
+
+VERSION = VERSION_MAJOR.VERSION_MINOR.VERSION_BUILD
+

--- a/src/App/main.cpp
+++ b/src/App/main.cpp
@@ -28,15 +28,18 @@
 ****************************************************************************/
 #include <QApplication>
 #include <QStyleFactory>
+#include <QVersionNumber>
 
 #include "mainwindow.h"
+#include "version.h"
 
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
 
     QCoreApplication::setApplicationName("AnimationMaker");
-    QCoreApplication::setApplicationVersion("1.8.4");
+    QVersionNumber version(VERSION_MAJOR, VERSION_MINOR, VERSION_BUILD);
+    QCoreApplication::setApplicationVersion(version.toString());
     QCoreApplication::setOrganizationName("Artanidos");
 
     QFont newFont("Sans Serif", 10);

--- a/src/App/version.h
+++ b/src/App/version.h
@@ -1,0 +1,8 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#define VERSION_MAJOR 1
+#define VERSION_MINOR 9
+#define VERSION_BUILD 0
+
+#endif // VERSION_H


### PR DESCRIPTION
Store the version number in a dedicated header.
Set the application version when starting.
Extract the version in build script.
Changing version number will force trigger a rebuild.