### PR TITLE
Issue 38 issue 43 add desktop file move to usr

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In order to build AnimationMaker you must first setup either *QtCreator* or inst
 First you must download and install QtCreator
 
 1. Download the QtCreator installer from [Qt website](https://www.qt.io/download-qt-installer).
-2. Run it, when choosing Qt library, choose **version  5.12**, this is the currently used version.
+2. Run it, when choosing Qt library, choose any version above **version 5.9.5**.
    Don't forget to pick the component 'gcc' in Qt version in order to obtain the necessary libraries
 3. Start QtCreator
 

--- a/assets/default.desktop
+++ b/assets/default.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Type=Application
 Name=AnimationMaker
-Exec=usr/bin/AnimationMaker
-Icon=default
-Comment=AnimationMaker
-Terminal=true
+Exec=animationmaker
+Icon=animationmaker.svg
+Comment=AnimationMaker - quicly build animations
+Terminal=false
+Version=1.0
 Categories=Graphics;

--- a/build_package.sh
+++ b/build_package.sh
@@ -14,8 +14,10 @@ fi
 BUILD_DIR="${2}"
 TYPE="${1}"
 SOURCE_DIR="${BUILD_DIR}/output"
-PLUGIN_DIR="${SOURCE_DIR}/plugins"
-INSTALL_PREFIX="/opt/animationmaker/"
+PLUGIN_DIR="${SOURCE_DIR}/opt/animationmaker/plugins"
+INSTALL_PREFIX="/"
+ICON="assets/default_64_64.svg"
+DESKTOP="assets/default.desktop"
 PACKAGE_DESCRIPTION="AnimationMaker is a software designed to help you to quickly build animations video.\n\n
 These animations can be exported to a video file/gif image or you can build your own export plugin."
 
@@ -49,8 +51,23 @@ minor=$(_extract_version "MINOR")
 build=$(_extract_version "BUILD")
 VERSION="${major}.${minor}.${build}"
 
-# rename the binary to lowercase letter to comply with deb packages
-mv ${SOURCE_DIR}/AnimationMaker ${SOURCE_DIR}/animationmaker
+# Copy .desktop entry and icon to apropriate folders
+if [[ ! -f ${ICON} ]]
+then
+    echo "Could not find icon file '${ICON}'"
+else
+    mkdir -p ${SOURCE_DIR}/usr/share/pixmaps
+    cp ${ICON} ${SOURCE_DIR}/usr/share/pixmaps/animationmaker.svg
+fi
+
+if [[ ! -f ${DESKTOP} ]]
+then
+    echo "Could not find desktop entry file '${DESKTOP}'"
+else
+    mkdir -p ${SOURCE_DIR}/usr/share/applications
+    cp ${DESKTOP} ${SOURCE_DIR}/usr/share/applications/animationmaker.desktop
+    chmod a+x ${SOURCE_DIR}/usr/share/applications/animationmaker.desktop
+fi
 
 if [[ "${TYPE}" == "deb" ]]
 then
@@ -80,4 +97,4 @@ fpm \
     --url "https://github.com/Artanidos/AnimationMaker" \
     --version ${VERSION} \
     ${deps[@]} \
-    animationmaker plugins
+    opt usr

--- a/src/App/App.pro
+++ b/src/App/App.pro
@@ -27,15 +27,15 @@ debug {
     DEFINES += DEBUG
 }
 
-TARGET = AnimationMaker
+TARGET = animationmaker
 TEMPLATE = app
 INSTALLS += target
 
 OBJECTS_DIR = objs/
 MOC_DIR = mocs/
 INCLUDEPATH += ../AnimationItems/
-DESTDIR = $$OUT_PWD/../../output
-target.path = /opt/animationmaker/
+DESTDIR = $$OUT_PWD/../../output/usr/bin/
+target.path = /usr/bin/animationmaker
 
 LIBS += -L$$OUT_PWD/../AnimationItems -lAnimationItems
 

--- a/src/App/mainwindow.cpp
+++ b/src/App/mainwindow.cpp
@@ -84,11 +84,10 @@ MainWindow::~MainWindow()
 
 void MainWindow::loadPlugins()
 {
-    QDir pluginsDir(QCoreApplication::applicationDirPath());
+    QDir pluginsDir = QDir();
 
     if (!pluginsDir.cd(PLUGIN_DIR)) {
         statusBar()->showMessage("Could not access plugin directory '" + PLUGIN_DIR + "'", 5000);
-
         return;
     }
 

--- a/src/App/mainwindow.h
+++ b/src/App/mainwindow.h
@@ -121,7 +121,7 @@ protected:
     QMenu *exportMenu;
     QUndoStack *m_undoStack;
     const QString FFMPEG = "ffmpeg";
-    const QString PLUGIN_DIR = "plugins";
+    const QString PLUGIN_DIR = "/opt/animationmaker/plugins";
     
 public slots:
     void reset();

--- a/src/plugins/Html/Html.pro
+++ b/src/plugins/Html/Html.pro
@@ -27,7 +27,7 @@ MOC_DIR       = mocs/
 
 DEPENDPATH   += ../../AnimationItems/
 INCLUDEPATH  += ../../AnimationItems/
-DESTDIR = $$OUT_PWD/../../../output/plugins
+DESTDIR = $$OUT_PWD/../../../output/opt/animationmaker/plugins/
 target.path = /opt/animationmaker/plugins
 
 LIBS         += -L$$OUT_PWD/../../AnimationItems -lAnimationItems

--- a/src/plugins/Pie/Pie.pro
+++ b/src/plugins/Pie/Pie.pro
@@ -27,7 +27,7 @@ MOC_DIR       = mocs/
 
 DEPENDPATH   += ../../AnimationItems/
 INCLUDEPATH  += ../../AnimationItems/
-DESTDIR = $$OUT_PWD/../../../output/plugins
+DESTDIR = $$OUT_PWD/../../../output/opt/animationmaker/plugins
 target.path = /opt/animationmaker/plugins
 
 LIBS         += -L$$OUT_PWD/../../AnimationItems -lAnimationItems


### PR DESCRIPTION
Closes #43 
Closes #38 

Provide a `.desktop` file for desktop menu entry.
Install main binary to `/usr/bin`
Update plugin loading path.
Update minimal Qt version to match ubuntu 18.04 version.