### PR TITLE
Prevent closing without saving

### DIFF
--- a/src/App/mainwindow.h
+++ b/src/App/mainwindow.h
@@ -71,6 +71,7 @@ protected:
     void runExport(QStringList &args, QString path);
     void addCheckboxes(QTreeWidgetItem *treeItem, AnimationItem *item);
     void addNewImage(AnimationScene::EditMode mode);
+    bool _saveAs();
 
     QProcess *m_proc;
     QString m_url;


### PR DESCRIPTION
Add a message box before closing offering 3 choices:
- close without saving
- cancel and go back to the editor
- save the file
  - if the project already has a saved file, use it
  - if not offer to choose a save file and save

closes #49 