### PR TITLE
Add ffmpeg to dependency list

### DIFF
--- a/build_package.sh
+++ b/build_package.sh
@@ -77,12 +77,14 @@ then
         "-d" "libqt5xml5"
         "-d" "libqt5widgets5"
         "-d" "libqt5svg5"
+        "-d" "ffmpeg"
     )
 else
     deps=(
         "-d" "qt5-qtbase"
         "-d" "qt5-qtbase-gui"
         "-d" "qt5-qtsvg"
+        "-d" "ffmpeg"
     )
 fi
 


### PR DESCRIPTION
FFMpeg is not mandatory to start the software but
without it we can't export anything.

closes #48 