### PR TITLE
Store UI elements in containers when they are too many

### DIFF
--- a/src/AnimationItems/animationitem.cpp
+++ b/src/AnimationItems/animationitem.cpp
@@ -48,21 +48,27 @@ AnimationItem::AnimationItem(AnimationScene *scene, bool isSceneRect)
 
     setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
 
-    delAct = new QAction(tr("Delete"), this);
+    QAction *delAct = new QAction(tr("Delete"), this);
     delAct->setShortcut(tr("Delete"));
     connect(delAct, SIGNAL(triggered()), this, SLOT(deleteItem()));
 
-    bringToFrontAct = new QAction("Bring to front");
+    QAction *bringToFrontAct = new QAction("Bring to front", this);
     connect(bringToFrontAct, SIGNAL(triggered()), this, SLOT(bringToFrontAction()));
 
-    sendToBackAct = new QAction("Send to back");
+    QAction *sendToBackAct = new QAction("Send to back", this);
     connect(sendToBackAct, SIGNAL(triggered()), this, SLOT(sendToBackAction()));
 
-    raiseAct = new QAction("Raise");
+    QAction *raiseAct = new QAction("Raise", this);
     connect(raiseAct, SIGNAL(triggered()), this, SLOT(raiseAction()));
 
-    lowerAct = new QAction("Lower");
+    QAction *lowerAct = new QAction("Lower", this);
     connect(lowerAct, SIGNAL(triggered()), this, SLOT(lowerAction()));
+
+    contextMenuActions.append(delAct);
+    contextMenuActions.append(bringToFrontAct);
+    contextMenuActions.append(sendToBackAct);
+    contextMenuActions.append(raiseAct);
+    contextMenuActions.append(lowerAct);
 
     m_contextMenu = new QMenu();
     m_contextMenu->addAction(delAct);
@@ -90,11 +96,6 @@ AnimationItem::~AnimationItem()
     }
     delete m_contextMenu;
     delete m_keyframes;
-    delete delAct;
-    delete bringToFrontAct;
-    delete sendToBackAct;
-    delete raiseAct;
-    delete lowerAct;
     if(m_hasHandles)
     {
         for(int i = 0; i < 8; i++)

--- a/src/AnimationItems/animationitem.h
+++ b/src/AnimationItems/animationitem.h
@@ -185,11 +185,7 @@ private:
     QRectF m_rect;
     QPen m_pen;
     QBrush m_brush;
-    QAction *delAct;
-    QAction *bringToFrontAct;
-    QAction *sendToBackAct;
-    QAction *lowerAct;
-    QAction *raiseAct;
+    QList<QAction *> contextMenuActions;
     QHash<QString, KeyFrame*> *m_keyframes;
     qreal m_oldx, m_oldy, m_oldwidth, m_oldheight;
     int m_opacity;

--- a/src/AnimationItems/coloreditor.cpp
+++ b/src/AnimationItems/coloreditor.cpp
@@ -38,27 +38,33 @@ ColorEditor::ColorEditor(QString label)
     m_hue = new QSpinBox();
     m_saturation = new QSpinBox();
     m_lightness = new QSpinBox();
-    m_labelHue = new QLabel("H");
-    m_labelSaturation = new QLabel("S");
-    m_labelLightness = new QLabel("L");
+    QLabel *m_labelHue = new QLabel("H");
+    QLabel *m_labelSaturation = new QLabel("S", this);
+    QLabel *m_labelLightness = new QLabel("L", this);
+
     m_red = new QSpinBox();
     m_green = new QSpinBox();
     m_blue = new QSpinBox();
-    m_labelRed = new QLabel("R");
-    m_labelGreen = new QLabel("G");
-    m_labelBlue = new QLabel("B");
+    QLabel *m_labelRed = new QLabel("R", this);
+    QLabel *m_labelGreen = new QLabel("G", this);
+    QLabel *m_labelBlue = new QLabel("B", this);
+
+    labelsRGB.append(m_labelRed);
+    labelsRGB.append(m_labelGreen);
+    labelsRGB.append(m_labelBlue);
+    labelsSHL.append(m_labelHue);
+    labelsSHL.append(m_labelLightness);
+    labelsSHL.append(m_labelSaturation);
+
     m_hue->setVisible(false);
     m_saturation->setVisible(false);
     m_lightness->setVisible(false);
     m_red->setVisible(false);
     m_green->setVisible(false);
     m_blue->setVisible(false);
-    m_labelHue->setVisible(false);
-    m_labelSaturation->setVisible(false);
-    m_labelLightness->setVisible(false);
-    m_labelRed->setVisible(false);
-    m_labelGreen->setVisible(false);
-    m_labelBlue->setVisible(false);
+    foreach(QLabel *l, labelsRGB + labelsSHL) {
+        l->setVisible(false);
+    }
     m_red->setMinimum(0);
     m_red->setMaximum(255);
     m_green->setMinimum(0);
@@ -71,12 +77,9 @@ ColorEditor::ColorEditor(QString label)
     m_saturation->setMaximum(100);
     m_lightness->setMinimum(0);
     m_lightness->setMaximum(100);
-    m_labelHue->setFixedWidth(15);
-    m_labelSaturation->setFixedWidth(15);
-    m_labelLightness->setFixedWidth(15);
-    m_labelRed->setFixedWidth(15);
-    m_labelGreen->setFixedWidth(15);
-    m_labelBlue->setFixedWidth(15);
+    foreach (QLabel *l, labelsRGB + labelsSHL) {
+        l->setFixedWidth(15);
+    }
     QLabel *l = new QLabel(label);
     l->setMinimumWidth(100);
     m_addKeyframe = new FlatButton(":/images/raute.png", ":/images/raute-hover.png");
@@ -156,15 +159,12 @@ void ColorEditor::setExpanded(bool value)
 {
     m_colorPicker->setVisible(value);
     m_hueSlider->setVisible(value);
-    m_labelHue->setVisible(value);
-    m_labelSaturation->setVisible(value);
-    m_labelLightness->setVisible(value);
     m_hue->setVisible(value);
     m_saturation->setVisible(value);
     m_lightness->setVisible(value);
-    m_labelRed->setVisible(value);
-    m_labelGreen->setVisible(value);
-    m_labelBlue->setVisible(value);
+    foreach (QLabel *l, labelsRGB + labelsSHL) {
+        l->setVisible(value);
+    }
     m_red->setVisible(value);
     m_green->setVisible(value);
     m_blue->setVisible(value);

--- a/src/AnimationItems/coloreditor.h
+++ b/src/AnimationItems/coloreditor.h
@@ -59,12 +59,8 @@ private:
     QSpinBox *m_blue;
     QLineEdit *m_color;
     ColorRect *m_rect;
-    QLabel *m_labelHue;
-    QLabel *m_labelSaturation;
-    QLabel *m_labelLightness;
-    QLabel *m_labelRed;
-    QLabel *m_labelGreen;
-    QLabel *m_labelBlue;
+    QList<QLabel *> labelsRGB;
+    QList<QLabel *> labelsSHL;
     FlatButton *m_addKeyframe;
 
     void setColorParts(QColor value);

--- a/src/AnimationItems/timeline.cpp
+++ b/src/AnimationItems/timeline.cpp
@@ -62,30 +62,30 @@ Timeline::Timeline(AnimationScene *scene)
     m_time = new QLabel();
     m_time->setText("0:00.0");
 
-    m_playAct = new QAction("Play");
-    m_playAct->setIcon(QIcon(":/images/play.png"));
-    m_playAct->setToolTip("Start the animation");
-    connect(m_playAct, SIGNAL(triggered()), this, SLOT(playAnimation()));
+    playAct = new QAction("Play", this);
+    playAct->setIcon(QIcon(":/images/play.png"));
+    playAct->setToolTip("Start the animation");
+    connect(playAct, SIGNAL(triggered()), this, SLOT(playAnimation()));
 
-    m_pauseAct = new QAction("Pause");
-    m_pauseAct->setIcon(QIcon(":/images/pause.png"));
-    m_pauseAct->setToolTip("Pause the animation");
-    connect(m_pauseAct, SIGNAL(triggered()), this, SLOT(pauseAnimation()));
+    pauseAct = new QAction("Pause", this);
+    pauseAct->setIcon(QIcon(":/images/pause.png"));
+    pauseAct->setToolTip("Pause the animation");
+    connect(pauseAct, SIGNAL(triggered()), this, SLOT(pauseAnimation()));
 
-    m_reverseAct = new QAction("Reverse");
-    m_reverseAct->setIcon(QIcon(":/images/reverse.png"));
-    m_reverseAct->setToolTip("Reverse the animation");
-    connect(m_reverseAct, SIGNAL(triggered()), this, SLOT(revertAnimation()));
+    reverseAct = new QAction("Reverse", this);
+    reverseAct->setIcon(QIcon(":/images/reverse.png"));
+    reverseAct->setToolTip("Reverse the animation");
+    connect(reverseAct, SIGNAL(triggered()), this, SLOT(revertAnimation()));
 
-    m_forwardAct = new QAction("Forward");
-    m_forwardAct->setIcon(QIcon(":/images/forward.png"));
-    m_forwardAct->setToolTip("Forward the animation");
-    connect(m_forwardAct, SIGNAL(triggered()), this, SLOT(forwardAnimation()));
+    forwardAct = new QAction("Forward", this);
+    forwardAct->setIcon(QIcon(":/images/forward.png"));
+    forwardAct->setToolTip("Forward the animation");
+    connect(forwardAct, SIGNAL(triggered()), this, SLOT(forwardAnimation()));
 
-    revertButton->setDefaultAction(m_reverseAct);
-    playButton->setDefaultAction(m_playAct);
-    pauseButton->setDefaultAction(m_pauseAct);
-    forwardButton->setDefaultAction(m_forwardAct);
+    revertButton->setDefaultAction(reverseAct);
+    playButton->setDefaultAction(playAct);
+    pauseButton->setDefaultAction(pauseAct);
+    forwardButton->setDefaultAction(forwardAct);
 
     hbox->addWidget(revertButton);
     hbox->addWidget(playButton);
@@ -97,7 +97,7 @@ Timeline::Timeline(AnimationScene *scene)
     hbox->addSpacing(5);
     hbox->addWidget(m_time);
     QGridLayout *layout = new QGridLayout;
-    m_tree = new QTreeWidget();
+    m_tree = new QTreeWidget(this);
     m_tree->setColumnCount(2);
     m_tree->header()->resizeSection(0, 205);
     m_tree->header()->close();
@@ -118,7 +118,7 @@ Timeline::Timeline(AnimationScene *scene)
     this->setLayout(layout);
 
     m_contextMenu = new QMenu();
-    m_delAct = new QAction("Delete");
+    m_delAct = new QAction("Delete", this);
 
     connect(m_tree, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onCustomContextMenu(const QPoint &)));
     connect(m_playhead, SIGNAL(valueChanged(int)), this, SLOT(playheadValueChanged(int)));
@@ -132,11 +132,6 @@ Timeline::Timeline(AnimationScene *scene)
 Timeline::~Timeline()
 {
     delete m_contextMenu;
-    delete m_delAct;
-    delete m_forwardAct;
-    delete m_pauseAct;
-    delete m_playAct;
-    delete m_reverseAct;
     delete m_tree;
 }
 

--- a/src/AnimationItems/timeline.h
+++ b/src/AnimationItems/timeline.h
@@ -94,10 +94,10 @@ private:
     QTreeWidget *m_tree;
     QMenu *m_contextMenu;
     QAction *m_delAct;
-    QAction *m_forwardAct;
-    QAction *m_pauseAct;
-    QAction *m_playAct;
-    QAction *m_reverseAct;
+    QAction *forwardAct;
+    QAction *pauseAct;
+    QAction *playAct;
+    QAction *reverseAct;
     AnimationScene *m_scene;
     PlayHead *m_playhead;
     QLabel *m_time;

--- a/src/App/mainwindow.h
+++ b/src/App/mainwindow.h
@@ -55,6 +55,11 @@ public:
     ~MainWindow() override;
 
     void setTitle();
+
+signals:
+    void enableSave(bool enabled);
+    void enableSaveItem(bool enabled);
+    void setCheckedSelectAct(bool checked);
     
 protected:
     void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
@@ -90,29 +95,14 @@ protected:
     QDockWidget *m_tooldock;
     QDockWidget *m_elementsdock;
     QTreeWidgetItem *m_root;
-    QAction *openAct;
-    QAction *newAct;
-    QAction *saveAct;
-    QAction *saveAsAct;
-    QAction *saveItemAsAct;
+    QList<QAction *> fileMenuActions;
     QAction *exitAct;
     QAction *aboutAct;
-    QAction *m_selectAct;
-    QAction *m_rectangleAct;
-    QAction *m_ellipseAct;
-    QAction *m_textAct;
-    QAction *m_svgAct;
-    QAction *m_bitmapAct;
-    QAction *showPropertyPanelAct;
-    QAction *showToolPanelAct;
-    QAction *showElementsAct;
+    QList<QAction *> toolPanelActions;
     QAction *showRulerAct;
+    QList<QAction *> viewMenuActions;
     QAction *exportMovieAct;
-    QAction *undoAct;
-    QAction *redoAct;
-    QAction *copyAct;
-    QAction *pasteAct;
-    QAction *delAct;
+    QList<QAction *> editMenuActions;
     QActionGroup *exportActionGroup;
     QMenu *fileMenu;
     QMenu *editMenu;
@@ -146,7 +136,7 @@ public slots:
     void showPropertyPanel();
     void showToolPanel();
     void showElementsPanel();
-    void showRuler();
+    void showRuler(bool checked);
     void sceneSelectionChanged();
     void timelineSelectionChanged(AnimationItem*);
     void copy();
@@ -159,6 +149,7 @@ public slots:
     void changeZoom(int zoom);
     void elementVisibleStateChanged(int);
     void elementLockStateChanged(int);
+
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
In some cases we can store UI elements in lists or maps
This allows to factorize actions applied on these elements
ex: `element->setVisible(true)`

closes #27