### PR TITLE
Fix mem leak in MainWindow

### DIFF
--- a/src/App/mainwindow.cpp
+++ b/src/App/mainwindow.cpp
@@ -71,8 +71,8 @@ MainWindow::MainWindow(QWidget *parent) :
 
 MainWindow::~MainWindow()
 {
-    delete exportMenu;
     delete m_itemPropertyEditor;
+    delete m_transitionEditor;
     delete m_scene;
     delete importMenu;
     delete m_timeline;


### PR DESCRIPTION
The attribute `m_transitionEditor` is allocated manually, it must be freed.
The attribute `exportMenu` is never allocated, do not free it,
remove it from the list of attributes as it is unused.